### PR TITLE
allow simple definitions to define lookup-tables on attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,26 @@ DataImport.run_config! 'mappings.rb', :only => ['Roles'] # => imports Roles only
 DataImport.run_config! 'mappings.rb', :only => ['Permissions'] # => imports Roles, SubscriptionPlans, Users and then Permissions
 ```
 
+### Lookup-Tables
+
+If you have tables referenced on other fields than their primary-key you need to perform lookups while migrating the data. data-import provides a feature called lookup-tables to basically create an index on any given field to the migrated primary-key.
+
+The following example shows a table `People` which is linked to the table `Organizations`. Sadly the legacy-schema used the field :code from the `Organizations`-table as reference.
+
+```ruby
+import 'Organizations' do
+  # define a lookup-table on the :code attribute
+  lookup_table_on :code
+end
+
+import 'People' do
+  mapping 'OrganizationCode' do |context, value|
+    # you can then use the previously defined lookup-table on :code to get the primary-key
+    {:org_id => context.definition('Organizations').identified_by(:code, value)}
+  end
+end
+```
+
 ## Examples
 
 you can learn a lot from the [integration specs](https://github.com/garaio/data-import/tree/master/spec/integration).

--- a/lib/data-import/definition.rb
+++ b/lib/data-import/definition.rb
@@ -1,3 +1,4 @@
+require 'data-import/definition/lookup'
 require 'data-import/definition/simple'
 
 module DataImport

--- a/lib/data-import/definition/lookup.rb
+++ b/lib/data-import/definition/lookup.rb
@@ -1,0 +1,37 @@
+module DataImport
+  class Definition
+    module Lookup
+
+      def initialize(*args)
+        @lookup_table_attributes = []
+        @lookup_tables = {}
+        super
+      end
+
+      def lookup_for(*attributes)
+        @lookup_table_attributes += attributes.map(&:to_sym)
+      end
+
+      def lookup_table_on?(attribute)
+        @lookup_table_attributes.include?(attribute.to_sym)
+      end
+
+      def add_mappings(id, row)
+        row.each do |key, value|
+          if lookup_table_on?(key)
+            lookup_table_for(key)[value] = id
+          end
+        end
+      end
+
+      def identify_by(attribute, value)
+        lookup_table_for(attribute)[value]
+      end
+
+      def lookup_table_for(attribute)
+        @lookup_tables[attribute] ||= {}
+      end
+
+    end
+  end
+end

--- a/lib/data-import/definition/simple.rb
+++ b/lib/data-import/definition/simple.rb
@@ -1,7 +1,9 @@
 module DataImport
   class Definition
     class Simple < Definition
-      attr_reader :id_mappings
+
+      include Lookup
+
       attr_reader :source_primary_key
       attr_accessor :source_table_name, :source_columns, :source_distinct_columns, :source_order_columns
       attr_accessor :target_table_name
@@ -11,7 +13,6 @@ module DataImport
       def initialize(name, source_database, target_database)
         super
         @mode = :insert
-        @id_mappings = {}
         @after_blocks = []
         @after_row_blocks = []
         @source_columns = []
@@ -24,14 +25,6 @@ module DataImport
 
       def source_primary_key=(value)
         @source_primary_key = value.to_sym unless value.nil?
-      end
-
-      def add_id_mapping(mapping)
-        @id_mappings.merge! mapping
-      end
-
-      def new_id_of(value)
-        @id_mappings[value]
       end
 
       def definition(name = nil)

--- a/lib/data-import/dsl/import.rb
+++ b/lib/data-import/dsl/import.rb
@@ -43,6 +43,10 @@ module DataImport
         end
       end
 
+      def lookup_for(*attributes)
+        definition.lookup_for(*attributes)
+      end
+
     end
   end
 end

--- a/lib/data-import/importer.rb
+++ b/lib/data-import/importer.rb
@@ -41,7 +41,7 @@ module DataImport
       case @definition.mode
       when :insert
         new_id = @definition.target_database.insert_row @definition.target_table_name, mapped_row
-        @definition.add_id_mapping row[@definition.source_primary_key] => new_id
+        @definition.add_mappings(new_id, row)
       when :update
         @definition.target_database.update_row(@definition.target_table_name, mapped_row)
       end

--- a/spec/data-import/definition/lookup_spec.rb
+++ b/spec/data-import/definition/lookup_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe DataImport::Definition::Lookup do
+
+  let(:example_class) do
+    Class.new do
+      include DataImport::Definition::Lookup
+    end
+  end
+
+  subject { example_class.new }
+
+  describe "lookup-table definition" do
+    it 'knows what attributes have a lookup-table' do
+      subject.lookup_for :code
+
+      subject.lookup_table_on?(:code).should be_true
+    end
+
+    it 'knows what attributes do not have a lookup-table' do
+      subject.lookup_for :code
+
+      subject.lookup_table_on?(:oldID).should be_false
+      subject.lookup_table_on?(:strRef).should be_false
+      subject.lookup_table_on?(:abcd).should be_false
+    end
+
+    it 'allows to define multiple lookup-tables in one call' do
+      subject.lookup_for :code, :oldID
+
+      subject.lookup_table_on?(:code).should be_true
+      subject.lookup_table_on?(:oldID).should be_true
+    end
+
+    it 'allows to define lookup-tables with multiple calls' do
+      subject.lookup_for :code
+      subject.lookup_for :strRef
+
+      subject.lookup_table_on?(:code).should be_true
+      subject.lookup_table_on?(:strRef).should be_true
+    end
+
+    it 'works with strings' do
+      subject.lookup_for 'a_string'
+
+      subject.lookup_table_on?(:a_string).should be_true
+    end
+
+    it 'works with symbols' do
+      subject.lookup_for :a_symbol
+
+      subject.lookup_table_on?('a_symbol').should be_true
+    end
+  end
+
+  describe 'mappings and lookups' do
+    before { subject.lookup_for :code }
+
+    it 'does not add any mappings when no lookup-attributes are given' do
+      lambda do
+        subject.add_mappings(66, :undefined_attribute => 'value-to-lookup')
+      end.should_not raise_error
+    end
+
+    it 'stores added mappings' do
+      id = 17
+      subject.add_mappings(id, :code => 'value-to-lookup')
+      subject.identify_by(:code, 'value-to-lookup').should == id
+    end
+  end
+end

--- a/spec/data-import/definition/simple_spec.rb
+++ b/spec/data-import/definition/simple_spec.rb
@@ -10,20 +10,6 @@ describe DataImport::Definition::Simple do
     end
   end
 
-  describe "#add_id_mapping" do
-    it "adds a primary key mapping to the definition" do
-      subject.add_id_mapping 18 => 24
-      subject.id_mappings[18].should == 24
-    end
-  end
-
-  describe "#new_id_of" do
-    it "looks for the new id in the id mappings" do
-      subject.add_id_mapping 39 => 834
-      subject.new_id_of(39).should == 834
-    end
-  end
-
   describe "#definition" do
     it "returns the definition of the importer if nothing is passed" do
       subject.definition.should == subject

--- a/spec/data-import/importer_spec.rb
+++ b/spec/data-import/importer_spec.rb
@@ -133,7 +133,7 @@ describe DataImport::Importer do
     it "adds the generated id to the id mapping of the definition" do
       definition.target_database.stub(:insert_row).and_return { 15 }
       definition.stub(:source_primary_key).and_return { :id }
-      definition.should_receive(:add_id_mapping).with(1 => 15)
+      definition.should_receive(:add_mappings).with(15, {:id => 1})
       subject.send(:import_row, :id => 1)
     end
 

--- a/spec/integration/lookup_tables_spec.rb
+++ b/spec/integration/lookup_tables_spec.rb
@@ -1,0 +1,79 @@
+require 'data-import'
+
+describe "lookup tables" do
+
+  let(:plan) do
+    DataImport::Dsl.define do
+      source :sequel, 'sqlite:/'
+      target :sequel, 'sqlite:/'
+
+      source_database.db.create_table :tblArticles do
+        primary_key :sArticleId
+        String :strRef
+      end
+
+      source_database.db.create_table :tblPosts do
+        primary_key :sPostId
+        String :strArticleRef
+      end
+
+      target_database.db.create_table :articles do
+        primary_key :id
+        String :slug
+      end
+
+      target_database.db.create_table :posts do
+        primary_key :id
+        Integer :article_id
+      end
+
+      import 'Articles' do
+        from 'tblArticles', :primary_key => 'sArticleId'
+        to 'articles'
+
+        lookup_for 'strRef'
+
+        mapping 'strRef' => 'slug'
+      end
+
+      import 'Posts' do
+        from 'tblPosts', :primary_key => 'sPostId'
+        to 'posts'
+        dependencies 'Articles'
+
+        mapping 'sPostId' => :id
+        mapping 'strArticleRef' do |context, value|
+          { :article_id => context.definition('Articles').identify_by(:strRef, value) }
+        end
+      end
+    end
+  end
+
+  let(:source_articles) { plan.definitions.first.source_database.db[:tblArticles] }
+  let(:source_posts) { plan.definitions.first.source_database.db[:tblPosts] }
+
+  let(:target_posts) { plan.definitions.first.target_database.db[:posts] }
+
+  before do
+    source_articles.insert(:sArticleId => 1,
+                           :strRef => 'data-import-is-awesome')
+    source_articles.insert(:sArticleId => 2,
+                           :strRef => 'ruby-is-awesome')
+    source_posts.insert(:sPostId => 7,
+                        :strArticleRef => 'ruby-is-awesome')
+    source_posts.insert(:sPostId => 8,
+                        :strArticleRef => 'data-import-is-awesome')
+    source_posts.insert(:sPostId => 9,
+                        :strArticleRef => 'ruby-is-awesome')
+
+  end
+
+
+  it 'mapps columns to the new schema' do
+    DataImport.run_plan!(plan)
+    target_posts.to_a.should == [{:id => 7, :article_id => 2},
+                                 {:id => 8, :article_id => 1},
+                                 {:id => 9, :article_id => 2}]
+  end
+
+end


### PR DESCRIPTION
This is an implementation for #9.
I removed the previous functionality called `id-mappings` so this breaks the current API. Before it would just create a lookup-table for every primary key. In this Implementaion you need to specify all lookup-tables excplicitly.

I'm not sure if it would be a good idea to add a lookup-table for every primary key specially considering the topic in #5.

//cc @stmichael 
