### PR TITLE
separate name and column of a lookup-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,11 @@ The following example shows a table `People` which is linked to the table `Organ
 
 ```ruby
 import 'Organizations' do
-  # define a lookup-table on the :code attribute
-  lookup_for :code
+  # define a lookup-table on the :sOrgId attribute named :sOrgId
+  lookup_for :sOrgId
+
+  # define a lookup-table on the :strCode attribute named :code
+  lookup_for :code, :column => 'strCode'
 end
 
 import 'People' do

--- a/lib/data-import/definition/lookup.rb
+++ b/lib/data-import/definition/lookup.rb
@@ -3,33 +3,68 @@ module DataImport
     module Lookup
 
       def initialize(*args)
-        @lookup_table_attributes = []
+        @lookup_table_configurations = {}
         @lookup_tables = {}
         super
       end
 
-      def lookup_for(*attributes)
-        @lookup_table_attributes += attributes.map(&:to_sym)
-      end
-
-      def lookup_table_on?(attribute)
-        @lookup_table_attributes.include?(attribute.to_sym)
+      def lookup_for(name, options = {})
+        config = LookupTableConfig.new(name, options)
+        if has_lookup_table_on?(config.attribute)
+          raise ArgumentError, "lookup-table for column '#{config.attribute}' was already defined"
+        else
+          @lookup_table_configurations[config.attribute] = config
+        end
       end
 
       def add_mappings(id, row)
-        row.each do |key, value|
-          if lookup_table_on?(key)
-            lookup_table_for(key)[value] = id
+        row.each do |attribute, value|
+          if has_lookup_table_on?(attribute)
+            name = config_for(attribute).name
+            lookup_table_named(name)[value] = id
           end
         end
       end
 
-      def identify_by(attribute, value)
-        lookup_table_for(attribute)[value]
+      def identify_by(name, value)
+        if has_lookup_table_named?(name)
+          lookup_table_named(name)[value]
+        else
+          raise ArgumentError, "no lookup-table defined named '#{name}'"
+        end
       end
 
-      def lookup_table_for(attribute)
-        @lookup_tables[attribute] ||= {}
+      def has_lookup_table_on?(attribute)
+        !!config_for(attribute.to_sym)
+      end
+
+      def has_lookup_table_named?(name)
+        @lookup_tables.has_key?(name.to_sym)
+      end
+
+      def config_for(attribute)
+        @lookup_table_configurations[attribute]
+      end
+
+      def lookup_table_named(name)
+        @lookup_tables[name] ||= {}
+      end
+
+      class LookupTableConfig
+        attr_accessor :name, :attribute
+
+        def initialize(name, options = {})
+          @name = name.to_sym
+          @attribute = if options.has_key?(:column)
+                         options[:column].to_sym
+                       else
+                         @name
+                       end
+        end
+
+        def for?(attribute)
+          @attribute = attribute
+        end
       end
 
     end


### PR DESCRIPTION
I noticed that it is very ugly to bind the lookup-table name and the column it is defined for together. this makes for very ugly lookup definitions because the old schema is all over the place.

I added a `:column` option so that the name and the column can be separated.

//cc @stmichael  
