### PR TITLE
execution context for blocks

### DIFF
--- a/lib/data-import/definition/mappings.rb
+++ b/lib/data-import/definition/mappings.rb
@@ -25,7 +25,7 @@ module DataImport
                                 else
                                   @columns.map {|column| row[column] }
                                 end
-        output_row.merge!(definition.instance_exec(*arguments, &@block) || {})
+        output_row.merge!(context.instance_exec(*arguments, &@block) || {})
       end
 
     end

--- a/lib/data-import/dsl/import.rb
+++ b/lib/data-import/dsl/import.rb
@@ -34,6 +34,7 @@ module DataImport
         mapping = if hash_or_symbols.first.is_a? Hash
                     Definition::Simple::NameMapping.new(*hash_or_symbols.first.first)
                   else
+                    puts 'after block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
                     Definition::Simple::BlockMapping.new(hash_or_symbols, block)
                   end
         definition.add_mapping(mapping)
@@ -52,14 +53,17 @@ module DataImport
       end
 
       def after(&block)
+        puts 'after block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
         definition.after_blocks << block
       end
 
       def after_row(&block)
+        puts 'after_row block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
         definition.after_row_blocks << block
       end
 
       def validate_row(&block)
+        puts 'validate_row block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
         definition.row_validation_blocks << block
       end
 

--- a/lib/data-import/dsl/import.rb
+++ b/lib/data-import/dsl/import.rb
@@ -34,7 +34,7 @@ module DataImport
         mapping = if hash_or_symbols.first.is_a? Hash
                     Definition::Simple::NameMapping.new(*hash_or_symbols.first.first)
                   else
-                    puts 'after block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
+                    check_block_arity(block)
                     Definition::Simple::BlockMapping.new(hash_or_symbols, block)
                   end
         definition.add_mapping(mapping)
@@ -53,19 +53,26 @@ module DataImport
       end
 
       def after(&block)
-        puts 'after block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
+        check_block_arity(block)
         definition.after_blocks << block
       end
 
       def after_row(&block)
-        puts 'after_row block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
+        check_block_arity(block)
         definition.after_row_blocks << block
       end
 
       def validate_row(&block)
-        puts 'validate_row block with a context parameter is deprecated and will be removed in later versions!' if block.arity > 0
+        check_block_arity(block)
         definition.row_validation_blocks << block
       end
+
+      def check_block_arity(block)
+        if block.arity > 0
+          warn "[DEPRECATION] blocks with parameters are deprecated and will be removed in later versions!\n#{caller[1]}"
+        end
+      end
+      private :check_block_arity
 
       def dependencies(*dependencies)
         dependencies.each do |dependency|

--- a/lib/data-import/importer.rb
+++ b/lib/data-import/importer.rb
@@ -14,7 +14,7 @@ module DataImport
           @progress_reporter.inc
         end
         @definition.after_blocks.each do |block|
-          @definition.instance_exec(@context, &block)
+          @context.instance_exec(@context, &block)
         end
       end
     end
@@ -22,7 +22,8 @@ module DataImport
     def map_row(row)
       mapped_row = {}
       @definition.mappings.each do |mapping|
-        mapping.apply!(@definition, @context, row, mapped_row)
+        local_context = @context.build_local_context(:row => row, :mapped_row => mapped_row)
+        mapping.apply!(@definition, local_context, row, mapped_row)
       end
       mapped_row
     end
@@ -35,14 +36,16 @@ module DataImport
         @definition.row_imported(new_id, row)
 
         @definition.after_row_blocks.each do |block|
-          @definition.instance_exec(@context, row, mapped_row, &block)
+          local_context = @context.build_local_context(:row => row, :mapped_row => mapped_row)
+          local_context.instance_exec(local_context, row, mapped_row, &block)
         end
       end
     end
 
     def row_valid?(row)
       @definition.row_validation_blocks.all? do |block|
-        @definition.instance_exec(@context, row, &block)
+        local_context = @context.build_local_context(:row => row)
+        local_context.instance_exec(local_context, row, &block)
       end
     end
     private :row_valid?

--- a/lib/data-import/runner.rb
+++ b/lib/data-import/runner.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module DataImport
   class Runner
 
@@ -11,8 +13,36 @@ module DataImport
       resolved_plan = dependency_resolver.resolve(:run_only => options[:only])
       resolved_plan.definitions.each do |definition|
         bar = @progress_reporter.new(definition.name, definition.total_steps_required)
-        definition.run(resolved_plan, bar)
+        definition.run(ExecutionContext.new(resolved_plan, definition), bar)
         bar.finish
+      end
+    end
+
+    class ExecutionContext < OpenStruct
+      def initialize(execution_plan, definition, values = {})
+        super(values)
+        @execution_plan = execution_plan
+        @definition = definition
+      end
+
+      def definition(name)
+        @execution_plan.definition(name)
+      end
+
+      def name
+        @definition.name
+      end
+
+      def source_database
+        @definition.source_database
+      end
+
+      def target_database
+        @definition.target_database
+      end
+
+      def build_local_context(values)
+        self.class.new(@execution_plan, @definition, values)
       end
     end
   end

--- a/spec/acceptance/dependencies_spec.rb
+++ b/spec/acceptance/dependencies_spec.rb
@@ -109,6 +109,7 @@ describe 'definition dependencies' do
 
         mapping 'sOwnerID' do |context, value|
           context.definition('Owners')
+          definition('Owners')
           {}
         end
       end

--- a/spec/unit/data-import/importer_spec.rb
+++ b/spec/unit/data-import/importer_spec.rb
@@ -6,7 +6,8 @@ describe DataImport::Importer do
   let(:target) { stub }
   let(:other_definition) { DataImport::Definition::Simple.new 'C', source, target }
   let(:definition) { DataImport::Definition::Simple.new 'A', source, target }
-  let(:context) { stub }
+  let(:context) { stub(:name => 'A', :build_local_context => local_context) }
+  let(:local_context) { stub }
   let(:progress_reporter) { stub }
   before { context.stub(:definition).with('C').and_return(other_definition) }
   subject { DataImport::Importer.new(context, definition, progress_reporter) }
@@ -121,7 +122,8 @@ describe DataImport::Importer do
                             :writer => writer,
                             :after_row_blocks => [],
                             :row_validation_blocks => []) }
-    let(:context) { stub }
+    let(:context) { stub(:build_local_context => local_context) }
+    let(:local_context) { stub }
     let(:writer) { mock }
 
 
@@ -130,8 +132,8 @@ describe DataImport::Importer do
     describe "#map_row" do
       it 'calls apply for all mappings' do
         legacy_row = {:legacy_id => 1, :legacy_name => 'hans'}
-        id_mapping.should_receive(:apply!).with(definition, context, legacy_row, {})
-        name_mapping.should_receive(:apply!).with(definition, context, legacy_row, {})
+        id_mapping.should_receive(:apply!).with(definition, local_context, legacy_row, {})
+        name_mapping.should_receive(:apply!).with(definition, local_context, legacy_row, {})
         subject.map_row(legacy_row).should == {}
       end
     end


### PR DESCRIPTION
@senny I created a first version of the execution context for blocks in the importer. Please take a look at it.

I'm not sure if it is a good idea to pass the execution plan and the current definition directly to the execution context because the context just needs a tiny part of the API of the two objects.

Another approach would be to pass the methods that the execution context should provide in its API. That would make it less dependable on the execution plan and the definition.
