### PR TITLE
look up tables for script blocks

### DIFF
--- a/lib/data-import/definition/script.rb
+++ b/lib/data-import/definition/script.rb
@@ -3,6 +3,8 @@ module DataImport
     class Script < Definition
       attr_accessor :body
 
+      include Lookup
+
       def run(context)
         target_database.transaction do
           context.instance_exec &body


### PR DESCRIPTION
Script blocks need to be able to write to and read from lookup tables. They already have access to other simple definitions lookup tables by using `definition('other definition').identify_by(:id, 8)` for example.

What's missing is the ability of the script block to create its own lookup table. I have a use case where I need exactly such behavior. In this commit I took the simplest approach to make it possible.
