### PR TITLE
validation block must have access to the original and mapped row

### DIFF
--- a/spec/acceptance/logger_spec.rb
+++ b/spec/acceptance/logger_spec.rb
@@ -11,7 +11,7 @@ describe 'logger' do
       mapping 'Gender' => :gender
 
       validate_row do
-        if row[:gender] == 'f'
+        if mapped_row[:gender] == 'f'
           true
         else
           logger.info "Row #{row} skipped since the gender is male"
@@ -43,7 +43,7 @@ describe 'logger' do
 
     DataImport.run_plan!(plan)
 
-    messages.string.strip.should == "Starting to import \"People\"\nRow {:name=>\"Jack\", :gender=>\"m\"} skipped since the gender is male"
+    messages.string.strip.should == "Starting to import \"People\"\nRow {:Name=>\"Jack\", :Gender=>\"m\"} skipped since the gender is male"
   end
 
 end

--- a/spec/acceptance/validate_row_spec.rb
+++ b/spec/acceptance/validate_row_spec.rb
@@ -10,8 +10,8 @@ describe 'validate rows before insertion' do
       mapping 'Name' => :name
       mapping 'Gender' => :gender
 
-      validate_row do |context, row|
-        row[:gender] == 'f'
+      validate_row do
+        mapped_row[:gender] == 'f'
       end
     end
   end


### PR DESCRIPTION
To output meaningful messages on a failed validation the validation block needs to have access to both the original and the mapped row.
