### PR TITLE
progress reporter available in the execution context

### DIFF
--- a/lib/data-import/definition/script.rb
+++ b/lib/data-import/definition/script.rb
@@ -6,6 +6,10 @@ module DataImport
       def run(context, progress_reporter)
         context.instance_exec &body
       end
+
+      def total_steps_required
+        100
+      end
     end
   end
 end

--- a/lib/data-import/runner.rb
+++ b/lib/data-import/runner.rb
@@ -15,7 +15,7 @@ module DataImport
         bar = @progress_reporter.new(definition.name, definition.total_steps_required)
 
         DataImport.logger.info "Starting to import \"#{definition.name}\""
-        definition.run(ExecutionContext.new(resolved_plan, definition), bar)
+        definition.run(ExecutionContext.new(resolved_plan, definition, :progress_reporter => bar), bar)
 
         bar.finish
       end

--- a/spec/acceptance/script_definition_spec.rb
+++ b/spec/acceptance/script_definition_spec.rb
@@ -18,6 +18,7 @@ describe "import with a script" do
         if source_database.db[:tblAnimal].filter(:name => 'Lion').empty?
           target_database.db[:animals].insert(:name => 'Lion', :king => true)
         end
+        progress_reporter.inc 100
       end
     end
   end


### PR DESCRIPTION
As discussed in issue #31.

Since the progress reporter gets created before knowing the maximum amount of steps, script blocks have a max of 100 so they can at least report in percents.
