### PR TITLE
refactoring: don't use OpenStruct because it is slow

### DIFF
--- a/lib/data-import/definition/script.rb
+++ b/lib/data-import/definition/script.rb
@@ -3,7 +3,7 @@ module DataImport
     class Script < Definition
       attr_accessor :body
 
-      def run(context, progress_reporter)
+      def run(context)
         target_database.transaction do
           context.instance_exec &body
         end

--- a/lib/data-import/definition/simple.rb
+++ b/lib/data-import/definition/simple.rb
@@ -26,8 +26,8 @@ module DataImport
         @mappings << mapping
       end
 
-      def run(context, progress_reporter)
-        Importer.new(context, self, progress_reporter).run
+      def run(context)
+        Importer.new(context, self).run
       end
 
       def total_steps_required

--- a/lib/data-import/execution_context.rb
+++ b/lib/data-import/execution_context.rb
@@ -1,8 +1,11 @@
-class ExecutionContext < OpenStruct
-  def initialize(execution_plan, definition, values = {})
-    super(values)
+class ExecutionContext
+
+  attr_reader :progress_reporter
+
+  def initialize(execution_plan, definition, progress_reporter)
     @execution_plan = execution_plan
     @definition = definition
+    @progress_reporter = progress_reporter
   end
 
   def logger
@@ -25,7 +28,15 @@ class ExecutionContext < OpenStruct
     @definition.target_database
   end
 
-  def build_local_context(values)
-    self.class.new(@execution_plan, @definition, values)
+  class Proxy
+    def initialize(context)
+      @context = context
+    end
+
+    [:logger, :definition, :name, :source_database, :target_database].each do |method_symbol|
+      define_method method_symbol do |*args|
+        @context.send(method_symbol, *args)
+      end
+    end
   end
 end

--- a/lib/data-import/runner.rb
+++ b/lib/data-import/runner.rb
@@ -13,7 +13,8 @@ module DataImport
         bar = @progress_reporter.new(definition.name, definition.total_steps_required)
 
         DataImport.logger.info "Starting to import \"#{definition.name}\""
-        definition.run(ExecutionContext.new(resolved_plan, definition, :progress_reporter => bar), bar)
+        context = ExecutionContext.new(resolved_plan, definition, bar)
+        definition.run context
 
         bar.finish
       end

--- a/spec/unit/data-import/definition/script_spec.rb
+++ b/spec/unit/data-import/definition/script_spec.rb
@@ -9,13 +9,12 @@ describe DataImport::Definition::Script do
     let(:context) { stub(:name => 'ABC') }
 
     it 'execute the definition and displays the progress' do
-      progress_reporter = stub
       found_name = nil
       subject.body = Proc.new { found_name = name }
 
       target.should_receive(:transaction).and_yield
 
-      subject.run(context, progress_reporter)
+      subject.run(context)
       found_name.should == 'ABC'
     end
   end

--- a/spec/unit/data-import/definition/simple/importer_spec.rb
+++ b/spec/unit/data-import/definition/simple/importer_spec.rb
@@ -6,17 +6,10 @@ describe DataImport::Definition::Simple::Importer do
   let(:target) { stub }
   let(:other_definition) { DataImport::Definition::Simple.new 'C', source, target }
   let(:definition) { DataImport::Definition::Simple.new 'A', source, target }
-  let(:context) { stub(:name => 'A') }
-  let(:before_context) { stub('context before mapping') }
-  let(:after_context) { stub('context after mapping') }
-  let(:progress_reporter) { stub }
+  let(:progress_reporter) { mock('ProgressReporter') }
+  let(:context) { mock('Context', :name => 'A', :progress_reporter => progress_reporter) }
   before { context.stub(:definition).with('C').and_return(other_definition) }
-  subject { described_class.new(context, definition, progress_reporter) }
-
-  before do
-    context.stub(:build_local_context).with(hash_including(:row)).and_return(before_context)
-    context.stub(:build_local_context).with(hash_including(:row, :mapped_row)).and_return(after_context)
-  end
+  subject { described_class.new(context, definition) }
 
   describe "#run" do
     let(:reader) { mock }
@@ -85,9 +78,7 @@ describe DataImport::Definition::Simple::Importer do
           true
         end
 
-        subject.should_receive(:map_row).with(before_context, {:id => 1}).and_return({:new_id => 1})
-        after_context.should_receive(:row).and_return({:id => 1})
-        after_context.should_receive(:mapped_row).and_return({:new_id => 1})
+        subject.should_receive(:map_row).with(instance_of(DataImport::Definition::Simple::Context), {:id => 1}).and_return({:new_id => 1})
         writer.should_receive(:write_row).any_number_of_times
 
         subject.import_row(:id => 1)
@@ -98,8 +89,6 @@ describe DataImport::Definition::Simple::Importer do
       it 'doesn\'t insert an invalid row' do
         definition.row_validation_blocks << Proc.new { false }
 
-        after_context.should_receive(:row).and_return({:id => 1})
-        after_context.should_receive(:mapped_row).and_return({:new_id => 1})
         writer.should_not_receive(:write_row)
 
         subject.import_row(:id => 1)
@@ -118,8 +107,8 @@ describe DataImport::Definition::Simple::Importer do
         output_rows << output_row
       end
 
-      subject.should_receive(:map_row).with(before_context, {:id => 1}).and_return({:new_id => 1})
-      subject.should_receive(:map_row).with(before_context, {:id => 2}).and_return({:new_id => 2})
+      subject.should_receive(:map_row).with(instance_of(DataImport::Definition::Simple::Context), {:id => 1}).and_return({:new_id => 1})
+      subject.should_receive(:map_row).with(instance_of(DataImport::Definition::Simple::Context), {:id => 2}).and_return({:new_id => 2})
       writer.should_receive(:write_row).any_number_of_times
       subject.import_row(:id => 1)
       subject.import_row(:id => 2)
@@ -140,14 +129,14 @@ describe DataImport::Definition::Simple::Importer do
     let(:writer) { mock }
 
 
-    subject { described_class.new(context, definition, nil) }
+    subject { described_class.new(context, definition) }
 
     describe "#map_row" do
       it 'calls apply for all mappings' do
         legacy_row = {:legacy_id => 1, :legacy_name => 'hans'}
-        id_mapping.should_receive(:apply!).with(definition, before_context, legacy_row, {})
-        name_mapping.should_receive(:apply!).with(definition, before_context, legacy_row, {})
-        subject.map_row(before_context, legacy_row).should == {}
+        id_mapping.should_receive(:apply!).with(definition, context, legacy_row, {})
+        name_mapping.should_receive(:apply!).with(definition, context, legacy_row, {})
+        subject.map_row(context, legacy_row).should == {}
       end
     end
 

--- a/spec/unit/data-import/definition/simple_spec.rb
+++ b/spec/unit/data-import/definition/simple_spec.rb
@@ -24,11 +24,10 @@ describe DataImport::Definition::Simple do
 
   describe '#run' do
     it 'executes the definition and displays the progress' do
-      progress_reporter = stub
       importer = mock
-      DataImport::Definition::Simple::Importer.should_receive(:new).with('CONTEXT', subject, progress_reporter).and_return(importer)
+      DataImport::Definition::Simple::Importer.should_receive(:new).with('CONTEXT', subject).and_return(importer)
       importer.should_receive(:run)
-      subject.run('CONTEXT', progress_reporter)
+      subject.run('CONTEXT')
     end
   end
 end


### PR DESCRIPTION
A benchmark revealed that `OpenStruct` is insanely slow compared to a normal `Struct`. I replaced the `#build_local_context` method with a specific `ExecutionContext::Proxy` and a specific implementation for the `Simple` definition.

I noticed that the progress_reporter was handed around. Since you added the reporter to the execution context some time ago I removed the duplicated references.
