### PR TITLE
disable postgres tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+env:
+  - ENABLE_POSTGRES_SPECS=true

--- a/spec/db_specific/postgres/update_sequence_spec.rb
+++ b/spec/db_specific/postgres/update_sequence_spec.rb
@@ -1,6 +1,6 @@
 require 'integration/spec_helper'
 
-describe DataImport::Sequel::Postgres::UpdateSequence do
+describe DataImport::Sequel::Postgres::UpdateSequence, :postgres => true do
   let(:table_name) { 'cities' }
   let(:connection) { DataImport::Database.connect('postgres://postgres@localhost/data_import_test') }
   subject { DataImport::Sequel::InsertWriter.new(connection, table_name) }

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -7,4 +7,5 @@ require File.join(File.dirname(__FILE__), '../acceptance/support/macros')
 
 RSpec.configure do |config|
   config.extend TestingMacros
+  config.filter_run_excluding :postgres => true unless ENV.has_key? 'ENABLE_POSTGRES_SPECS'
 end


### PR DESCRIPTION
Just a suggestion, but since I needed it anyway I made a pull-request out of it:

Let's give the option to enable and disable platform/database specific tests. Why? For me, it's just that I have a different connection string for postgres. We could make it possible to pass it in, however, someone else might not have postgresql installed. As long as the platform-specific tests are run on travis before merge, I think it's more intuitive (for new developers) if the tests pass right away and no extra setup is required.

Let me know what you think.
